### PR TITLE
Better handling of aborted books and better handling of errors from Bloom CLI

### DIFF
--- a/src/Harvester/HarvestMode.cs
+++ b/src/Harvester/HarvestMode.cs
@@ -4,7 +4,8 @@ namespace BloomHarvester
 {
 	public enum HarvestMode
 	{
-		All,
+		ForceAll,	// Same as "All" but will process books even if they are reported as In Progress.
+		All,	// Processes all books normally, except for books that are already In Progress by something else
 		Default,
 		RetryFailuresOnly,
 		NewOrUpdatedOnly,

--- a/src/Harvester/Parse/Model/HarvestState.cs
+++ b/src/Harvester/Parse/Model/HarvestState.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BloomHarvester.Parse.Model
+﻿namespace BloomHarvester.Parse.Model
 {
 	public enum HarvestState
 	{
@@ -14,5 +8,6 @@ namespace BloomHarvester.Parse.Model
 		InProgress,
 		Done,
 		Failed,
+		Aborted
 	}
 }

--- a/src/Harvester/Program.cs
+++ b/src/Harvester/Program.cs
@@ -36,7 +36,6 @@ namespace BloomHarvester
 		public static void Main(string[] args)
 		{
 			// See https://github.com/commandlineparser/commandline for documentation about CommandLine.Parser
-
 			var parser = new CommandLine.Parser((settings) =>
 			{
 				settings.CaseInsensitiveEnumValues = true;

--- a/src/Harvester/WebLibraryIntegration/YouTrackIssueConnector.cs
+++ b/src/Harvester/WebLibraryIntegration/YouTrackIssueConnector.cs
@@ -116,9 +116,6 @@ namespace BloomHarvester.WebLibraryIntegration   // Review: Could posisibly put 
 			}
 
 			ReportToYouTrack(_youTrackProjectKeyMissingFonts, summary, description, description, exitImmediately: false);
-		}
-		
-
-		
+		}		
 	}
 }

--- a/src/Harvester/WebLibraryIntegration/YouTrackIssueConnector.cs
+++ b/src/Harvester/WebLibraryIntegration/YouTrackIssueConnector.cs
@@ -12,7 +12,7 @@ namespace BloomHarvester.WebLibraryIntegration   // Review: Could posisibly put 
 	internal class YouTrackIssueConnector
 	{
 		private static readonly string _issueTrackingBackend = "issues.bloomlibrary.org";
-		private static readonly string _youTrackProjectKeyExceptions = "BL";  // Or "SB" for Sandbox
+		private static readonly string _youTrackProjectKeyErrors = "BL";  // Or "SB" for Sandbox
 		private static readonly string _youTrackProjectKeyMissingFonts = "BH";  // Or "SB" for Sandbox
 
 		private static void ReportToYouTrack(string projectKey, string summary, string description, string consoleMessage, bool exitImmediately)
@@ -56,7 +56,7 @@ namespace BloomHarvester.WebLibraryIntegration   // Review: Could posisibly put 
 			string description = GetIssueDescriptionFromException(exception, additionalDescription);
 			string consoleMessage = "Exception was:\n" + exception.ToString();
 
-			ReportToYouTrack(_youTrackProjectKeyExceptions, summary, description, consoleMessage, exitImmediately);
+			ReportToYouTrack(_youTrackProjectKeyErrors, summary, description, consoleMessage, exitImmediately);
 		}
 
 		private static string GetIssueDescriptionFromException(Exception exception, string additionalDescription)
@@ -101,6 +101,20 @@ namespace BloomHarvester.WebLibraryIntegration   // Review: Could posisibly put 
 			return bldr.ToString();
 		}
 
+		public static void ReportErrorToYouTrack(string errorSummary, string errorDetails, Parse.Model.Book book = null)
+		{
+			string summary = $"[BH] Error: {errorSummary}";
+
+			string description = "";
+			if (book != null)
+			{
+				description = $"Book: {book.ObjectId ?? "null"} ({book.BaseUrl ?? "No URL"})\n";
+			}
+			description += errorDetails;
+
+			ReportToYouTrack(_youTrackProjectKeyErrors, summary, description, description, exitImmediately: false);
+		}
+
 		public static void ReportMissingFontToYouTrack(string missingFontName, string harvesterId, Parse.Model.Book book = null)
 		{
 			string summary = $"[BH] Missing Font: \"{missingFontName}\"";
@@ -116,6 +130,6 @@ namespace BloomHarvester.WebLibraryIntegration   // Review: Could posisibly put 
 			}
 
 			ReportToYouTrack(_youTrackProjectKeyMissingFonts, summary, description, description, exitImmediately: false);
-		}		
+		}
 	}
 }


### PR DESCRIPTION
There are 2 commits, probably easier to review one commit at a time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/27)
<!-- Reviewable:end -->
