### PR TITLE
Fix bug if book contains inconsistent lang tags (BL-7707)

### DIFF
--- a/src/Harvester/BloomHarvester.csproj
+++ b/src/Harvester/BloomHarvester.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net461</TargetFramework>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-	<AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-	<AssemblyInformationalVersion>1.0.0.0</AssemblyInformationalVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+	<AssemblyFileVersion>1.1.0.0</AssemblyFileVersion>
+	<AssemblyInformationalVersion>1.1.0.0</AssemblyInformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Harvester/BookAnalyzer.cs
+++ b/src/Harvester/BookAnalyzer.cs
@@ -23,16 +23,9 @@ namespace BloomHarvester
 		public BookAnalyzer(string html, string meta)
 		{
 			_dom = new HtmlDom(XmlHtmlConverter.GetXmlDomFromHtml(html, false));
-			Language1Code = _dom.SelectSingleNode(
-					"//div[contains(@class, 'bloom-editable') and contains(@class, 'bloom-content1') and @lang]")
-				?.Attributes["lang"]?.Value ?? "";
-			// Bloom defaults language 2 to en if not specified.
-			Language2Code = _dom.SelectSingleNode(
-					"//div[contains(@class, 'bloom-editable') and contains(@class, 'bloom-content2') and @lang]")
-				?.Attributes["lang"]?.Value ?? "en";
-			Language3Code = _dom.SelectSingleNode(
-					"//div[contains(@class, 'bloom-editable') and contains(@class, 'bloom-content3') and @lang]")
-				?.Attributes["lang"]?.Value ?? "";
+			Language1Code = GetBestLangCode(1) ?? "";
+			Language2Code = GetBestLangCode(2) ?? "en";
+			Language3Code = GetBestLangCode(3) ?? "";
 
 			var metaObj = DynamicJson.Parse(meta);
 			if (metaObj.IsDefined("brandingProjectName"))
@@ -50,6 +43,62 @@ namespace BloomHarvester
 			using (var writer = XmlWriter.Create(sb))
 				bloomCollectionElement.WriteTo(writer);
 			BloomCollection = sb.ToString();
+		}
+
+		/// <summary>
+		/// Gets the language code for the specified language number
+		/// </summary>
+		/// <param name="x">The language number</param>
+		/// <returns>The most frequently occurring value of the "lang" attribute</returns>
+		private string GetBestLangCode(int x)
+		{
+			string xpathString = $"//div[contains(@class, 'bloom-editable') and contains(@class, 'bloom-content{x}') and @lang]";
+			string langCode = GetBestLangCodeFromNodeList(_dom.SafeSelectNodes(xpathString));
+			return langCode;
+		}
+
+		/// <summary>
+		/// Gets the most-frequently occuring lang code among the nodes in the specified node list
+		/// </summary>
+		/// <param name="nodeList"></param>
+		/// <returns>The most frequently occuring lang code. May return null</returns>
+		public static string GetBestLangCodeFromNodeList(XmlNodeList nodeList)
+		{
+			if (nodeList == null)
+			{
+				return null;
+			}
+
+			// Get the frequency count for each language code
+			var frequencyCounts = new Dictionary<string, uint>();
+			for (int i = 0; i < nodeList.Count; ++i)
+			{
+				var xmlNode = nodeList.Item(i);
+				var lang = xmlNode.Attributes["lang"]?.Value;
+
+				if (!frequencyCounts.TryGetValue(lang, out uint count))
+				{
+					count = 0;
+				}
+				++count;
+
+				frequencyCounts[lang] = count;
+			}
+
+			// Now get the language with the maximum count
+			string langWithHighestCount = null;
+			uint highestCount = 0;
+			foreach (var kvp in frequencyCounts)
+			{
+				uint count = kvp.Value;
+				if (count > highestCount)
+				{
+					highestCount = count;
+					langWithHighestCount = kvp.Key;
+				}
+			}
+			
+			return langWithHighestCount;
 		}
 
 		public static BookAnalyzer FromFolder(string bookFolder)

--- a/src/Harvester/BookAnalyzer.cs
+++ b/src/Harvester/BookAnalyzer.cs
@@ -49,56 +49,18 @@ namespace BloomHarvester
 		/// Gets the language code for the specified language number
 		/// </summary>
 		/// <param name="x">The language number</param>
-		/// <returns>The most frequently occurring value of the "lang" attribute</returns>
+		/// <returns>The language code for the specified language, as determined from the bloomDataDiv. Returns null if not found.</returns>
 		private string GetBestLangCode(int x)
 		{
-			string xpathString = $"//div[contains(@class, 'bloom-editable') and contains(@class, 'bloom-content{x}') and @lang]";
-			string langCode = GetBestLangCodeFromNodeList(_dom.SafeSelectNodes(xpathString));
-			return langCode;
-		}
-
-		/// <summary>
-		/// Gets the most-frequently occuring lang code among the nodes in the specified node list
-		/// </summary>
-		/// <param name="nodeList"></param>
-		/// <returns>The most frequently occuring lang code. May return null</returns>
-		public static string GetBestLangCodeFromNodeList(XmlNodeList nodeList)
-		{
-			if (nodeList == null)
+			string xpathString = $"//*[@id='bloomDataDiv']/*[@data-book='contentLanguage{x}']";
+			var matchingNodes = _dom.SafeSelectNodes(xpathString);
+			if (matchingNodes.Count == 0)
 			{
 				return null;
 			}
-
-			// Get the frequency count for each language code
-			var frequencyCounts = new Dictionary<string, uint>();
-			for (int i = 0; i < nodeList.Count; ++i)
-			{
-				var xmlNode = nodeList.Item(i);
-				var lang = xmlNode.Attributes["lang"]?.Value;
-
-				if (!frequencyCounts.TryGetValue(lang, out uint count))
-				{
-					count = 0;
-				}
-				++count;
-
-				frequencyCounts[lang] = count;
-			}
-
-			// Now get the language with the maximum count
-			string langWithHighestCount = null;
-			uint highestCount = 0;
-			foreach (var kvp in frequencyCounts)
-			{
-				uint count = kvp.Value;
-				if (count > highestCount)
-				{
-					highestCount = count;
-					langWithHighestCount = kvp.Key;
-				}
-			}
-			
-			return langWithHighestCount;
+			var matchedNode = matchingNodes.Item(0);
+			string langCode = matchedNode.InnerText.Trim();
+			return langCode;
 		}
 
 		public static BookAnalyzer FromFolder(string bookFolder)

--- a/src/Harvester/Harvester.cs
+++ b/src/Harvester/Harvester.cs
@@ -421,6 +421,11 @@ namespace BloomHarvester
 					_currentBookId = null;
 					_parseClient.UpdateObject(book.GetParseClassName(), book.ObjectId, finalUpdates.ToJson());
 				}
+
+				// Cleanup the download directory if everything was successful.
+				// (If it failed, I guess it's fine to skip deleting it because having the download around makes debugging easier)
+				SIL.IO.RobustIO.DeleteDirectoryAndContents(downloadBookDir);
+
 				_logger.TrackEvent("ProcessOneBook End - " + (isSuccessful ? "Success" : "Error"));
 			}
 			catch (Exception e)

--- a/src/HarvesterTests/BookAnalyzerTests.cs
+++ b/src/HarvesterTests/BookAnalyzerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Linq;
 using Bloom.web.controllers;
 using BloomHarvester;
@@ -34,8 +35,16 @@ namespace BloomHarvesterTests
 
 	        <div class='marginBox'>
 	            <div class='bloom-translationGroup bloom-trailingElement normal-style'>
+	                <div aria-describedby='qtip-0' data-hasqtip='true' class='bloom-editable bloom-content1 normal-style' contenteditable='true' lang='quc'>
+	                    False Alarm<br>
+	                </div>
+
 	                <div aria-describedby='qtip-0' data-hasqtip='true' class='bloom-editable bloom-content1 normal-style' contenteditable='true' lang='xk'>
 	                    Normal English<br>
+	                </div>
+
+	                <div aria-describedby='qtip-0' data-hasqtip='true' class='bloom-editable bloom-content1 normal-style' contenteditable='true' lang='xk'>
+	                    Some more English<br>
 	                </div>
 
 	                <div aria-describedby='qtip-1' data-hasqtip='true' class='bloom-editable bloom-content2 normal-style' contenteditable='true' lang='fr'>
@@ -69,6 +78,33 @@ namespace BloomHarvesterTests
 			_oneLanguageAnalyzer = new BookAnalyzer(oneLangHtml, meta.Replace("{0}", ""));
 
 			_threeLanguageCollection = XElement.Parse(_threeLanguageAnalyzer.BloomCollection);
+		}
+
+		[Test]
+		public void Language1Code_ConflictingLang1Codes_PicksMajority()
+		{
+			// This test setups its own test scenario. It doesn't rely on the OneTimeSetup of the class.
+			var document = new XmlDocument();
+			var rootElement = document.CreateElement("root");
+			document.AppendChild(rootElement);
+
+			var node1 = document.CreateElement("div");
+			node1.SetAttribute("class", "data-content1");
+			node1.SetAttribute("lang", "quc");
+			rootElement.AppendChild(node1);
+
+			var node2 = document.CreateElement("div");
+			node2.SetAttribute("class", "data-content1");
+			node2.SetAttribute("lang", "es");
+			rootElement.AppendChild(node2);
+
+			var node3 = document.CreateElement("div");
+			node3.SetAttribute("class", "data-content1");
+			node3.SetAttribute("lang", "es");
+			rootElement.AppendChild(node3);
+
+			var langCode = BookAnalyzer.GetBestLangCodeFromNodeList(rootElement.ChildNodes);
+			Assert.That(langCode, Is.EqualTo("es"));
 		}
 
 		[Test]


### PR DESCRIPTION
Take this book as an example: https://bloomlibrary.org/browse/detail/vdDvZy7OUL?shelf=Ministerio%20de%20Educaci%C3%B3n%20de%20Guatemala

It has 2 instances of bloom-content1 which say lang="quc", but tons of bloom-content1 instances which say lang="es".
The old code picks "quc" for it, and then some of the publishing code crashes at the mixup in what the right language1/title should be.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/34)
<!-- Reviewable:end -->
