### PR TITLE
Harvester Exception handling (BL-7702)

### DIFF
--- a/src/Harvester/EnvironmentSetting.cs
+++ b/src/Harvester/EnvironmentSetting.cs
@@ -7,11 +7,12 @@ namespace BloomHarvester
 {
 	public enum EnvironmentSetting
 	{
+		Unknown,
 		Default,
+		Local,
 		Dev,
 		Test,
-		Prod,
-		Local
+		Prod
 	}
 
 	internal class EnvironmentUtils

--- a/src/Harvester/Harvester.cs
+++ b/src/Harvester/Harvester.cs
@@ -290,7 +290,16 @@ namespace BloomHarvester
 				}
 				catch (Exception e)
 				{
-					YouTrackIssueConnector.ReportExceptionToYouTrack(e, $"Unhandled exception thrown while running Harvest() function.", exitImmediately: false);
+					try
+					{
+						YouTrackIssueConnector.ReportExceptionToYouTrack(e, $"Unhandled exception thrown while running Harvest() function.", exitImmediately: false);
+					}
+					catch (Exception)
+					{
+						// There was an error in reporting the error...
+						// That's unfortunate, but we don't want to propagate another exception higher up. Because that would suspend our loop
+						Console.Error.WriteLine("Exception thrown while attempting to report exception to YouTrack");
+					}
 				}
 
 			} while (_options.Loop);

--- a/src/Harvester/Harvester.cs
+++ b/src/Harvester/Harvester.cs
@@ -27,6 +27,7 @@ namespace BloomHarvester
 
 		protected IMonitorLogger _logger;
 		private ParseClient _parseClient;
+		private EnvironmentSetting _parseDBEnvironment;
 		private BookTransfer _transfer;
 		private HarvesterS3Client _s3UploadClient;  // Note that we upload books to a different bucket than we download them from, so we have a separate client.
 		private HarvesterOptions _options;
@@ -64,13 +65,13 @@ namespace BloomHarvester
 			}
 
 			// Setup Parse Client and S3 Clients
-			EnvironmentSetting parseDBEnvironment = EnvironmentUtils.GetEnvOrFallback(options.ParseDBEnvironment, options.Environment);
-			_parseClient = new ParseClient(parseDBEnvironment);
+			_parseDBEnvironment = EnvironmentUtils.GetEnvOrFallback(options.ParseDBEnvironment, options.Environment);
+			_parseClient = new ParseClient(_parseDBEnvironment);
 			_parseClient.Logger = _logger;
 
 			string downloadBucketName;
 			string uploadBucketName;
-			switch (parseDBEnvironment)
+			switch (_parseDBEnvironment)
 			{
 				case EnvironmentSetting.Prod:
 					downloadBucketName = BloomS3Client.ProductionBucketName;
@@ -88,11 +89,11 @@ namespace BloomHarvester
 					break;
 			}
 			_transfer = new BookTransfer(_parseClient,
-				bloomS3Client: new HarvesterS3Client(downloadBucketName, parseDBEnvironment, true),
+				bloomS3Client: new HarvesterS3Client(downloadBucketName, _parseDBEnvironment, true),
 				htmlThumbnailer: null,
 				bookDownloadStartingEvent: new Bloom.BookDownloadStartingEvent());
 
-			_s3UploadClient = new HarvesterS3Client(uploadBucketName, parseDBEnvironment, false);
+			_s3UploadClient = new HarvesterS3Client(uploadBucketName, _parseDBEnvironment, false);
 
 			// Setup a handler that is called when the console is closed
 			consoleExitHandler = new ConsoleEventDelegate(ConsoleEventCallback);
@@ -292,7 +293,7 @@ namespace BloomHarvester
 				{
 					try
 					{
-						YouTrackIssueConnector.ReportExceptionToYouTrack(e, $"Unhandled exception thrown while running Harvest() function.", exitImmediately: false);
+						YouTrackIssueConnector.ReportExceptionToYouTrack(e, $"Unhandled exception thrown while running Harvest() function.", _parseDBEnvironment, exitImmediately: false);
 					}
 					catch (Exception)
 					{
@@ -437,7 +438,7 @@ namespace BloomHarvester
 				isSuccessful = false;
 				string bookId = book?.ObjectId ?? "null";
 				string bookUrl = book?.BaseUrl ?? "null";
-				YouTrackIssueConnector.ReportExceptionToYouTrack(e, $"Unhandled exception thrown while processing book objectId={bookId}, baseUrl={bookUrl}", exitImmediately: false);
+				YouTrackIssueConnector.ReportExceptionToYouTrack(e, $"Unhandled exception thrown while processing book objectId={bookId}, baseUrl={bookUrl}", _parseDBEnvironment, exitImmediately: false);
 
 				// Attempt to write to Parse that processing failed
 				if (!String.IsNullOrEmpty(book?.ObjectId))
@@ -719,7 +720,7 @@ namespace BloomHarvester
 
 					if (!_missingFonts.Contains(missingFont))
 					{
-						YouTrackIssueConnector.ReportMissingFontToYouTrack(missingFont, this.Identifier, book);
+						YouTrackIssueConnector.ReportMissingFontToYouTrack(missingFont, this.Identifier, _parseDBEnvironment, book);
 						_missingFonts.Add(missingFont);
 					}
 					else
@@ -852,7 +853,7 @@ namespace BloomHarvester
 						_logger.LogError(errorDetails);
 						errorDetails += $"\n===StandardOut===\n{bloomStdOut ?? ""}\n";
 						errorDetails += $"\n===StandardError===\n{bloomStdErr ?? ""}";
-						YouTrackIssueConnector.ReportErrorToYouTrack("Harvester BloomCLI Error", errorDetails);
+						YouTrackIssueConnector.ReportErrorToYouTrack("Harvester BloomCLI Error", errorDetails, _parseDBEnvironment);
 					}
 					else
 					{

--- a/src/Harvester/Program.cs
+++ b/src/Harvester/Program.cs
@@ -63,7 +63,7 @@ namespace BloomHarvester
 			}
 			catch (Exception e)
 			{
-				YouTrackIssueConnector.ReportExceptionToYouTrack(e, "An exception was thrown which was not handled by the program.");
+				YouTrackIssueConnector.ReportExceptionToYouTrack(e, "An exception was thrown which was not handled by the program.", EnvironmentSetting.Unknown);
 				throw;
 			}
 		}

--- a/src/Harvester/WebLibraryIntegration/YouTrackIssueConnector.cs
+++ b/src/Harvester/WebLibraryIntegration/YouTrackIssueConnector.cs
@@ -50,19 +50,20 @@ namespace BloomHarvester.WebLibraryIntegration   // Review: Could posisibly put 
 			return youTrackIssueId;
 		}
 
-		internal static void ReportExceptionToYouTrack(Exception exception, string additionalDescription = "", bool exitImmediately = true)
+		internal static void ReportExceptionToYouTrack(Exception exception, string additionalDescription, EnvironmentSetting environment, bool exitImmediately = true)
 		{
 			string summary = $"[BH] Exception \"{exception.Message}\"";
-			string description = GetIssueDescriptionFromException(exception, additionalDescription);
+			string description = GetIssueDescriptionFromException(exception, additionalDescription, environment);
 			string consoleMessage = "Exception was:\n" + exception.ToString();
 
 			ReportToYouTrack(_youTrackProjectKeyErrors, summary, description, consoleMessage, exitImmediately);
 		}
 
-		private static string GetIssueDescriptionFromException(Exception exception, string additionalDescription)
+		private static string GetIssueDescriptionFromException(Exception exception, string additionalDescription, EnvironmentSetting environment)
 		{
 			StringBuilder bldr = new StringBuilder();
 			bldr.AppendLine($"Error Report from Bloom Harvester on {DateTime.UtcNow.ToUniversalTime()} (UTC):");
+			bldr.AppendLine($"Environment: {environment}");
 			bldr.AppendLine(additionalDescription);
 			bldr.AppendLine();
 
@@ -101,7 +102,7 @@ namespace BloomHarvester.WebLibraryIntegration   // Review: Could posisibly put 
 			return bldr.ToString();
 		}
 
-		public static void ReportErrorToYouTrack(string errorSummary, string errorDetails, Parse.Model.Book book = null)
+		public static void ReportErrorToYouTrack(string errorSummary, string errorDetails, EnvironmentSetting environment, Parse.Model.Book book = null)
 		{
 			string summary = $"[BH] Error: {errorSummary}";
 
@@ -110,12 +111,13 @@ namespace BloomHarvester.WebLibraryIntegration   // Review: Could posisibly put 
 			{
 				description = $"Book: {book.ObjectId ?? "null"} ({book.BaseUrl ?? "No URL"})\n";
 			}
+			description += $"Environment: {environment}\n";
 			description += errorDetails;
 
 			ReportToYouTrack(_youTrackProjectKeyErrors, summary, description, description, exitImmediately: false);
 		}
 
-		public static void ReportMissingFontToYouTrack(string missingFontName, string harvesterId, Parse.Model.Book book = null)
+		public static void ReportMissingFontToYouTrack(string missingFontName, string harvesterId, EnvironmentSetting environment, Parse.Model.Book book = null)
 		{
 			string summary = $"[BH] Missing Font: \"{missingFontName}\"";
 
@@ -128,6 +130,7 @@ namespace BloomHarvester.WebLibraryIntegration   // Review: Could posisibly put 
 			{
 				description = $"Missing font \"{missingFontName}\" referenced in book {book.ObjectId} ({book.BaseUrl}) on machine \"{harvesterId}\".";
 			}
+			description += $"Environment: {environment}\n";
 
 			ReportToYouTrack(_youTrackProjectKeyMissingFonts, summary, description, description, exitImmediately: false);
 		}


### PR DESCRIPTION
1) Don't crash if an exception is thrown while reporting to YouTrack. (We want the Harvester to continue running the loop in such a case, not abort the program).
2) Add the Parse Environment setting into the issue report as well for easier diagnostics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/35)
<!-- Reviewable:end -->
