### PR TITLE
Add ability to batch set Parse objects to a specific state (for BL-7909)

### DIFF
--- a/src/Harvester/HarvestStateBatchUpdater.cs
+++ b/src/Harvester/HarvestStateBatchUpdater.cs
@@ -1,0 +1,58 @@
+﻿using BloomHarvester.Parse;
+using BloomHarvester.Parse.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BloomHarvester
+{
+	internal class HarvestStateBatchUpdater : Harvester
+	{
+		private HarvestState NewState { get; set; }
+
+		private HarvestStateBatchUpdater(BatchUpdateStateInParseOptions options)
+			: base(new HarvesterOptions()
+			{
+				QueryWhere = options.QueryWhere,
+				ParseDBEnvironment = options.ParseDBEnvironment,
+				Environment = EnvironmentSetting.Local,
+				SuppressLogs = true
+			})
+		{
+			NewState = options.NewState;
+		}
+
+		internal static void RunBatchUpdateStates(BatchUpdateStateInParseOptions options)
+		{
+			using (HarvestStateBatchUpdater updater = new HarvestStateBatchUpdater(options))
+			{
+				updater.BatchUpdateStates();
+			}
+		}
+
+		/// <summary>
+		/// This function is here to allow setting the harvesterState to specific values for all rows matching the queryWhere condition
+		/// </summary>
+		private void BatchUpdateStates()
+		{
+			IEnumerable<Book> bookList = _parseClient.GetBooks(_options.QueryWhere);
+
+			foreach (var book in bookList)
+			{
+				_logger.LogInfo($"Updating objectId {book.ObjectId} from {book.HarvestState} to {NewState}");
+				
+				string newStateStr = "";
+				if (NewState != HarvestState.Unknown)
+				{
+					newStateStr = NewState.ToString();
+				}
+
+				var updateOp = new BookUpdateOperation();
+				updateOp.UpdateFieldWithString(Book.kHarvestStateField, newStateStr);
+				_parseClient.UpdateObject(book.GetParseClassName(), book.ObjectId, updateOp.ToJson());
+			}
+			_parseClient.FlushBatchableOperations();
+		}
+	}
+}

--- a/src/Harvester/HarvestStateUpdater.cs
+++ b/src/Harvester/HarvestStateUpdater.cs
@@ -26,7 +26,7 @@ namespace BloomHarvester
 			parseClient.UpdateObject(Book.GetStaticParseClassName(), objectId, updateOp.ToJson());
 			parseClient.FlushBatchableOperations();
 
-			Console.Out.WriteLine($"Evnironment={parseDbEnvironment}: Sent request to update object \"{objectId}\" with harvestState={newState}");
+			Console.Out.WriteLine($"Environment={parseDbEnvironment}: Sent request to update object \"{objectId}\" with harvestState={newState}");
 		}
 	}
 }


### PR DESCRIPTION
Associated with: https://issues.bloomlibrary.org/youtrack/issue/BL-7909

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/49)
<!-- Reviewable:end -->
