### PR TITLE
Make delayAfterEmptyRunSecs configurable

### DIFF
--- a/src/Harvester/HarvestStateBatchUpdater.cs
+++ b/src/Harvester/HarvestStateBatchUpdater.cs
@@ -58,6 +58,7 @@ namespace BloomHarvester
 				}
 			}
 
+			_logger.LogInfo($"{bookList.Count()} objects processed.");
 			if (!IsDryRun)
 			{
 				_parseClient.FlushBatchableOperations();

--- a/src/Harvester/Harvester.cs
+++ b/src/Harvester/Harvester.cs
@@ -24,9 +24,9 @@ namespace BloomHarvester
 	{
 		private const int kCreateArtifactsTimeoutSecs = 300;
 		private const int kGetFontsTimeoutSecs = 20;
-		private const int kDelayAfterEmptyRunSecs = 300;
 		private const bool kEnableLoggingSkippedBooks = false;
 
+		private int _delayAfterEmptyRunSecs = 300;
 		protected IMonitorLogger _logger;
 		protected ParseClient _parseClient;
 		private EnvironmentSetting _parseDBEnvironment;
@@ -67,6 +67,11 @@ namespace BloomHarvester
 			{
 				EnvironmentSetting azureMonitorEnvironment = EnvironmentUtils.GetEnvOrFallback(options.LogEnvironment, options.Environment);
 				_logger = new AzureMonitorLogger(azureMonitorEnvironment, this.Identifier);
+			}
+
+			if (options.LoopWaitSeconds >= 0)
+			{
+				_delayAfterEmptyRunSecs = options.LoopWaitSeconds;
 			}
 
 			// Setup Parse Client and S3 Clients
@@ -281,9 +286,9 @@ namespace BloomHarvester
 
 						if (numBooksProcessed == 0)
 						{
-							var estimatedResumeTime = DateTime.Now.AddSeconds(kDelayAfterEmptyRunSecs);
+							var estimatedResumeTime = DateTime.Now.AddSeconds(_delayAfterEmptyRunSecs);
 							Console.Out.WriteLine($"Waiting till: {estimatedResumeTime.ToString("h:mm:ss tt")}...");
-							Thread.Sleep(kDelayAfterEmptyRunSecs * 1000);
+							Thread.Sleep(_delayAfterEmptyRunSecs * 1000);
 						}
 						else
 						{

--- a/src/Harvester/Program.cs
+++ b/src/Harvester/Program.cs
@@ -113,6 +113,9 @@ namespace BloomHarvester
 		[Option("loop", Required = false, Default = false, HelpText = "If true, will keep re-running Harvester after it finishes.")]
 		public bool Loop { get; set; }
 
+		[Option("loopWaitSeconds", Required = false, Default = 300, HelpText = "If specified, and loop mode is on, then specifies the number of seconds to wait between loop iterations if nothing was previously processed")]
+		public int LoopWaitSeconds { get; set; }
+
 		[Option("skipDownload", Required = false, Default = false, HelpText = "If true, will skip downloading the book if it already exists.")]
 		public bool SkipDownload { get; set; }
 


### PR DESCRIPTION
Otherwise, it needs to be recompiled and re-built to change the value. If you wanted to change its value on a machine running the Harvester (and it downloads the binaries), this would be a big nuisance for a small thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/51)
<!-- Reviewable:end -->
