### PR TITLE
Add missing dependency required by libtidy

### DIFF
--- a/src/HarvesterTests/BloomHarvesterTests.csproj
+++ b/src/HarvesterTests/BloomHarvesterTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
@@ -26,6 +26,8 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+	<!-- Copy libtidy and its dependency, msvcr120.dll -->
     <Exec Command="copy /Y &quot;$(SolutionDir)\lib\dotnet\libtidy.dll&quot; $(OutDir)" />
+	<Exec Command="copy /Y &quot;$(SolutionDir)\lib\dotnet\msvcr120.dll&quot; $(OutDir)" />
   </Target>
 </Project>


### PR DESCRIPTION
No longer requires the machine running the test to just happen to have the appropriate DLL already installed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/72)
<!-- Reviewable:end -->
