### PR TITLE
Decrease likelihood of error if multiple Harvesters running

### DIFF
--- a/src/Harvester/EnvironmentSetting.cs
+++ b/src/Harvester/EnvironmentSetting.cs
@@ -27,12 +27,12 @@ namespace BloomHarvester
 		{
 			EnvironmentSetting parsedEnv = resourceEnv;
 
-			if (resourceEnv != EnvironmentSetting.Default)
+			if (resourceEnv != EnvironmentSetting.Unknown && resourceEnv != EnvironmentSetting.Default)
 			{
 				// Individual resource's environment was specified. Lets use it directly.
 				parsedEnv = resourceEnv;
 			}
-			else if (fallbackEnv != EnvironmentSetting.Default)
+			else if (fallbackEnv != EnvironmentSetting.Unknown && fallbackEnv != EnvironmentSetting.Default)
 			{
 				// Resource environment not specified, but general environment parameter was.
 				// Fallback to general environment parameter
@@ -45,7 +45,7 @@ namespace BloomHarvester
 			}
 
 			// Verify Postcondition: Should not return Environment.Default
-			Debug.Assert(parsedEnv != EnvironmentSetting.Default, "GetEnvironment should determine a specific, non-default value of Environment");
+			Debug.Assert(parsedEnv != EnvironmentSetting.Unknown && parsedEnv != EnvironmentSetting.Default, "GetEnvironment should determine a specific, non-default value of Environment");
 
 			return parsedEnv;
 		}

--- a/src/HarvesterTests/HarvesterTests.cs
+++ b/src/HarvesterTests/HarvesterTests.cs
@@ -47,6 +47,25 @@ namespace BloomHarvesterTests
 			return book;
 		}
 
+		[TestCase("Dev", "Dev")]
+		[TestCase("Dev", "Local")]
+		public void HarvesterGetUniqueIdentifier_TwoInstances_ReturnDifferentValues(string env1, string env2)
+		{
+			using (var harvester1 = new Harvester(new HarvesterOptions() { Environment = (EnvironmentSetting)Enum.Parse(typeof(EnvironmentSetting), env1), SuppressLogs = true}))
+			{
+				var obj = new VSUnitTesting.PrivateObject(harvester1);
+				obj.SetField("_initTime", DateTime.Now.AddSeconds(-1));
+
+				using (var harvester2 = new Harvester(new HarvesterOptions() { Environment = (EnvironmentSetting)Enum.Parse(typeof(EnvironmentSetting), env2), SuppressLogs = true }))
+				{
+					var id1 = harvester1.GetUniqueIdentifier();
+					var id2 = harvester2.GetUniqueIdentifier();
+
+					Assert.That(id1, Is.Not.EqualTo(id2));
+				}
+			}
+		}
+
 		#region ShouldProcessBook() tests
 		#region Default mode
 		// Process cases


### PR DESCRIPTION
This PR makes it more likely that two Harvesters can run side-by-side on the same user account on a machine.

However, for our actual Harvester instances, I'm converting them to run on separate user accounts on the same machine instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/77)
<!-- Reviewable:end -->
