### PR TITLE
Calculate computedLevel properly on pure comic books

### DIFF
--- a/src/Harvester/BookAnalyzer.cs
+++ b/src/Harvester/BookAnalyzer.cs
@@ -205,7 +205,7 @@ namespace BloomHarvester
 				++pageCount;
 				int wordCountForThisPage = 0;
 
-				IEnumerable<XmlElement> editables = GetEditablesFromPage(pageElement, Language1Code, includeImageDescriptions: false, includeTextOverPicture: false);
+				IEnumerable<XmlElement> editables = GetEditablesFromPage(pageElement, Language1Code, includeImageDescriptions: false, includeTextOverPicture: true);
 				foreach (var editable in editables)
 				{
 					wordCountForThisPage += GetWordCount(editable.InnerText);
@@ -231,8 +231,13 @@ namespace BloomHarvester
 		/// </summary>
 		internal static int GetWordCount(string text)
 		{
+			if (String.IsNullOrWhiteSpace(text))
+				return 0;
+			// FYI, GetWordsFromHtmlString() (which is a port from our JS code) returns an array containing the empty string
+			// if the input to it is the empty string. So handle that...
+
 			var words = GetWordsFromHtmlString(text);
-			return words.Length;
+			return words.Where(x => !String.IsNullOrEmpty(x)).Count();
 		}
 
 		private static readonly Regex kHtmlLinebreakRegex = new Regex("/<br><\\/br>|<br>|<br \\/>|<br\\/>|\r?\n/", RegexOptions.Compiled);


### PR DESCRIPTION
Previously, textOverPicture boxes were being excluded from the word count. Now they are included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/83)
<!-- Reviewable:end -->
