### PR TITLE
Prevent Harvester from trying to run on Linux (BL-8475)

### DIFF
--- a/src/Harvester/Program.cs
+++ b/src/Harvester/Program.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BloomHarvester.WebLibraryIntegration;
 using CommandLine;
+using Gecko;
 
 [assembly: InternalsVisibleTo("BloomHarvesterTests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]	// Needed for NSubstitute to create mock objects
@@ -42,6 +43,13 @@ namespace BloomHarvester
 		[STAThread]
 		public static void Main(string[] args)
 		{
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+			{
+				// See  https://issues.bloomlibrary.org/youtrack/issue/BL-8475.
+				Console.WriteLine("Harvester cannot run on Linux until we verify that phash computations always yield the same result on both Windows and Linux!");
+				return;
+			}
+
 			// See https://github.com/commandlineparser/commandline for documentation about CommandLine.Parser
 			var parser = new CommandLine.Parser((settings) =>
 			{


### PR DESCRIPTION
At the moment, phash computation results can differ between Windows and
Linux.  This would have to be dealt with somehow before we could run
Harvester on a Linux machine instead of a Windows machine.

(This is currently moot because Harvester won't even build on Linux, but
this change should give pause to moving in that direction.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/94)
<!-- Reviewable:end -->
