### PR TITLE
Remove the reference to Geckofx45 from harvester

### DIFF
--- a/src/Harvester/BloomHarvester.csproj
+++ b/src/Harvester/BloomHarvester.csproj
@@ -24,7 +24,6 @@
 		<PackageReference Include="CommandLineParser" Version="2.5.0" />
 		<PackageReference Include="DesktopAnalytics" Version="1.2.4.11" />
 		<PackageReference Include="EasyHttp" Version="1.7.0" />
-		<PackageReference Include="Geckofx45" Version="45.0.28" />
 		<PackageReference Include="Microsoft.ApplicationInsights.TraceListener" Version="2.10.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
 		<PackageReference Include="RestSharp" Version="105.2.3" />

--- a/src/Harvester/Program.cs
+++ b/src/Harvester/Program.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BloomHarvester.WebLibraryIntegration;
 using CommandLine;
-using Gecko;
 
 [assembly: InternalsVisibleTo("BloomHarvesterTests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]	// Needed for NSubstitute to create mock objects


### PR DESCRIPTION
It isn't needed and is never used.  And Bloom has moved on to Geckofx60.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/99)
<!-- Reviewable:end -->
