### PR TITLE
Allow ePUBs to fail without making the entire harvest fail

### DIFF
--- a/src/HarvesterTests/HarvesterTests.cs
+++ b/src/HarvesterTests/HarvesterTests.cs
@@ -750,6 +750,9 @@ namespace BloomHarvesterTests
 				var book = BookTests.CreateDefaultBook();
 				ConfigureForFakeIndexHtmFile(harvester, book.Model.Title);
 				SetupMockBookDownloadHandler(book.Model.ObjectId, harvester);
+				// Harvester now checks that the epub file exists before trying to upload it.  So fake it.
+				var epubPath = Path.Combine(Path.GetTempPath(), $"BHStaging-{harvester.GetUniqueIdentifier()}", $"{book.Model.Title}.epub");
+				_fakeFileIO.Configure().Exists(epubPath).Returns(true);
 
 				// System under test				
 				harvester.ProcessOneBook(book);


### PR DESCRIPTION
Comic books won't produce ePUB files, but will produce all of the other
artifacts okay.  Bloom has already been fixed to not crash trying to
create ePUBs for comic books.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/116)
<!-- Reviewable:end -->
