### PR TITLE
Simplify and bulletproof build/copyBloomDependencies.sh (20200722)

### DIFF
--- a/build/copyBloomDependencies.sh
+++ b/build/copyBloomDependencies.sh
@@ -1,31 +1,25 @@
-#!/bin/bash
-#
-# Usage: ./copyBloomDependncies.sh [bloomDesktopRootDir]
+#!/bin/sh
 
-bloomDir="$1"
+set -e
 
-buildModes=("Debug" "Release")
+cd "$(dirname "$0")"
 
-for mode in "${buildModes[@]}"
-do
-	:
-	harvestBuildDir="../src/Harvester/bin/$mode/net461/"
+buildMode="Debug"
+if [ -n "$1" ]; then
+    bloomDir="$1";
+    if [ -n "$2" ]; then buildMode="$2"; fi
+else
+    echo "Usage: copyBloomDependencies.sh BloomDesktopRootDir [BuildMode]"
+    echo "    BloomDesktopRootDir looks something like \"c:/src/BloomDesktop\" or \"/d/github/BloomMaster\"."
+    echo "    BuildMode is either \"Debug\" or \"Release\".  It defaults to Debug."
+    exit 1
+fi
 
-	cp "$bloomDir/output/$mode/Bloom.exe" "$harvestBuildDir/Bloom.exe"
-
-	mkdir -p "$harvestBuildDir/browser"
-	cp -r "$bloomDir/output/browser/bookEdit" "$harvestBuildDir/browser/bookEdit"
-	cp -r "$bloomDir/output/browser/bookLayout" "$harvestBuildDir/browser/bookLayout"
-	cp -r "$bloomDir/output/browser/bookPreview" "$harvestBuildDir/browser/bookPreview"
-	cp -r "$bloomDir/output/browser/branding" "$harvestBuildDir/browser/branding"
-	cp -r "$bloomDir/output/browser/collection" "$harvestBuildDir/browser/collection"
-	cp -r "$bloomDir/output/browser/lib" "$harvestBuildDir/browser/lib"
-	cp -r "$bloomDir/output/browser/publish" "$harvestBuildDir/browser/publish"
-	cp -r "$bloomDir/output/browser/templates" "$harvestBuildDir/browser/templates"
-	cp -r "$bloomDir/output/browser/themes" "$harvestBuildDir/browser/themes"
-
-	mkdir -p "$harvestBuildDir/DistFiles"
-	cp -r "$bloomDir/DistFiles/localization" "$harvestBuildDir/DistFiles/localization"
-	cp "$bloomDir/DistFiles/BloomBlankPage.htm" "$harvestBuildDir/DistFiles/"
-	cp "$bloomDir/DistFiles/connections.dll" "$harvestBuildDir/DistFiles/"
-done
+echo removing all files and folders from lib/dotnet
+rm -rf ../lib/dotnet/*
+echo copying files from \"$bloomDir/output/$buildMode\" to lib/dotnet
+cp -r "$bloomDir/output/$buildMode/"* ../lib/dotnet
+echo copying files from \"$bloomDir/output/browser\" to lib/dotnet
+cp -r "$bloomDir/output/browser" ../lib/dotnet
+echo copying files from \"$bloomDir/DistFiles\" to lib/dotnet
+cp -r "$bloomDir/DistFiles" ../lib/dotnet


### PR DESCRIPTION
It may not be quite bulletproof, but it works a lot better for my normal
usage.  It works in the git-bash shell, but fails in the cygwin shell
because of the CRLF line endings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/117)
<!-- Reviewable:end -->
