### PR TITLE
Upgrade packages to match BloomDesktop

### DIFF
--- a/src/Harvester/BloomHarvester.csproj
+++ b/src/Harvester/BloomHarvester.csproj
@@ -19,15 +19,16 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Autofac" Version="4.1.1" />
-		<PackageReference Include="AWSSDK.S3" Version="3.3.102.11" />
+		<PackageReference Include="Autofac" Version="6.0.0" />
+		<PackageReference Include="AWSSDK.S3" Version="3.5.1.10" />
 		<PackageReference Include="CoenM.ImageSharp.ImageHash" Version="1.0.0-beta0004" />
-		<PackageReference Include="CommandLineParser" Version="2.5.0" />
+		<PackageReference Include="CommandLineParser" Version="2.8.0" />
 		<PackageReference Include="DesktopAnalytics" Version="1.2.4.11" />
 		<PackageReference Include="EasyHttp" Version="1.7.0" />
 		<PackageReference Include="Microsoft.ApplicationInsights.TraceListener" Version="2.10.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-		<PackageReference Include="RestSharp" Version="105.2.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+		<PackageReference Include="RestSharp" Version="106.11.7" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
BloomDesktop recently upgraded its dependencies, so Harvester does too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/121)
<!-- Reviewable:end -->
