### PR TITLE
Create Harvester youtrack issues for New or Updated Books (BL-8919)

### DIFF
--- a/src/Harvester/AlertManager.cs
+++ b/src/Harvester/AlertManager.cs
@@ -3,21 +3,30 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using BloomHarvester.Parse.Model;
 
 namespace BloomHarvester
 {
 	/// <summary>
-	/// This class keeps track of alerts that are reported and whether alerts should be silenced for being too "noisy" (frequent)	///
-	/// Use the TryReportAlerts(out bool isSilenced) function to do this
+	/// This class keeps track of alerts that are reported and whether alerts should be silenced for being too "noisy" (frequent)
+	/// Use the RecordAlertAndCheckIfSilenced() function to do this
 	/// </summary>
 	public class AlertManager
 	{
 		internal const int kMaxAlertCount = 5;
 		const int kLookbackWindowInHours = 24;
 
+		internal class Alert
+		{
+			internal DateTime TimeStamp;
+			internal string BookUrl;
+			internal string HarvestState;
+			internal string UploaderId;
+		}
+
 		private AlertManager()
 		{
-			_alertTimes = new LinkedList<DateTime>();
+			_alerts = new LinkedList<Alert>();
 		}
 
 		// Singleton access
@@ -36,7 +45,7 @@ namespace BloomHarvester
 		}
 
 		// Other fields/properties
-		private LinkedList<DateTime> _alertTimes;	// This list should be maintained in ascending order
+		private LinkedList<Alert> _alerts;	// This list should be maintained in ascending time order
 		internal IMonitorLogger Logger { get; set; }
 
 		// Methods
@@ -45,11 +54,18 @@ namespace BloomHarvester
 		/// Tells the AlertManager to record that an alert is taking place. Also checks if the alert should be silenced or not
 		/// </summary>
 		/// <returns>Returns true if the current alert should be silenced, false otherwise</returns>
-		public bool RecordAlertAndCheckIfSilenced()
+		public bool RecordAlertAndCheckIfSilenced(BookModel bookModel = null)
 		{
-			_alertTimes.AddLast(DateTime.Now);
+			var timeStamp = new Alert()
+			{
+				TimeStamp = DateTime.Now,
+				BookUrl = bookModel?.BaseUrl,
+				HarvestState = bookModel?.HarvestState,
+				UploaderId = bookModel?.Uploader.ObjectId,
+			};
+			_alerts.AddLast(timeStamp);
 
-			bool isSilenced = this.IsSilenced();
+			bool isSilenced = this.IsSilenced(bookModel);
 			if (isSilenced && Logger != null)
 			{
 				Logger.TrackEvent("AlertManager: An alert was silenced (too many alerts).");
@@ -63,21 +79,35 @@ namespace BloomHarvester
 		/// </summary>
 		public void Reset()
 		{
-			_alertTimes.Clear();
+			_alerts.Clear();
 		}
 
 		/// <summary>
 		/// Returns whether alerts should currently be silenced
 		/// </summary>
 		/// <returns>Returns true for silenced, false for not silenced</returns>
-		private bool IsSilenced()
+		private bool IsSilenced(BookModel bookModel = null)
 		{
 			// Determine how many alerts have been fired since the start time of the lookback period
 			PruneList();
 
+			// Allow reports for "New" or "Updated" books even after exceeding the daily quota for bug
+			// reports in general.  But limit to one report per book or MAX reports per uploader.  (Of
+			// course, if the uploader persists with one book MAX times, no reports will appear for other
+			// books that get uploaded later the same day.)
+			// See https://issues.bloomlibrary.org/youtrack/issue/BL-8919.
+			if (bookModel?.HarvestState == "New" || bookModel?.HarvestState == "Updated")
+			{
+				var countForThisBook = _alerts.Count(stamp => stamp?.BookUrl == bookModel.BaseUrl);
+				if (countForThisBook > 1)
+					return true;		// silence if this book has been reported already today
+				var countForUploader = _alerts.Count(stamp => stamp?.UploaderId == bookModel.Uploader.ObjectId);
+				return countForUploader > kMaxAlertCount;	// silence for too many errors caused by books from the same uploader.
+			}
+
 			// Current model has the same (well, inverted) condition for entering and exiting the Silenced state.
 			// Another model could use unrelated conditions for entering vs. exiting the Silenced state
-			return _alertTimes.Count > kMaxAlertCount;
+			return _alerts.Count > kMaxAlertCount;
 		}
 
 		/// <summary>
@@ -88,9 +118,9 @@ namespace BloomHarvester
 			DateTime startTime = DateTime.Now.Subtract(TimeSpan.FromHours(kLookbackWindowInHours));
 
 			// Precondition: This list must be in sorted order
-			while (_alertTimes.Any() && _alertTimes.First.Value < startTime)
+			while (_alerts.Any() && _alerts.First.Value.TimeStamp < startTime)
 			{
-				_alertTimes.RemoveFirst();
+				_alerts.RemoveFirst();
 			}
 		}
 	}

--- a/src/Harvester/WebLibraryIntegration/YouTrackIssueConnector.cs
+++ b/src/Harvester/WebLibraryIntegration/YouTrackIssueConnector.cs
@@ -51,7 +51,7 @@ namespace BloomHarvester.WebLibraryIntegration
 		}
 		internal List<ErrorReport> TestErrorReports = new List<ErrorReport>();
 
-		private void ReportToYouTrack(string projectKey, string summary, string description, bool exitImmediately)
+		private void ReportToYouTrack(string projectKey, string summary, string description, bool exitImmediately, BookModel bookModel = null)
 		{
 			Console.Error.WriteLine("ERROR: " + summary);
 			Console.Error.WriteLine("==========================");
@@ -73,7 +73,7 @@ namespace BloomHarvester.WebLibraryIntegration
 			}
 			else
 			{
-				string youTrackIssueId = SubmitToYouTrack(summary, description, projectKey);
+				string youTrackIssueId = SubmitToYouTrack(summary, description, projectKey, bookModel);
 				if (!String.IsNullOrEmpty(youTrackIssueId))
 				{
 					Console.Out.WriteLine($"Created YouTrack issue {youTrackIssueId}");
@@ -91,9 +91,9 @@ namespace BloomHarvester.WebLibraryIntegration
 			}
 		}
 
-		internal static string SubmitToYouTrack(string summary, string description, string youTrackProjectKey)
+		internal static string SubmitToYouTrack(string summary, string description, string youTrackProjectKey, BookModel bookModel = null)
 		{
-			bool isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced();
+			bool isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(bookModel);
 			if (isSilenced)
 			{
 				// Alerts are silenced because too many alerts.
@@ -119,7 +119,7 @@ namespace BloomHarvester.WebLibraryIntegration
 				GetDiagnosticInfo(bookModel, this.EnvironmentSetting) + "\n\n" +
 				GetIssueDescriptionFromException(exception);
 
-			ReportToYouTrack(_youTrackProjectKeyErrors, summary, description, exitImmediately);
+			ReportToYouTrack(_youTrackProjectKeyErrors, summary, description, exitImmediately, bookModel);
 		}
 
 		private static string GetIssueDescriptionFromException(Exception exception)
@@ -169,7 +169,7 @@ namespace BloomHarvester.WebLibraryIntegration
 				GetDiagnosticInfo(bookModel, this.EnvironmentSetting) + '\n' +
 				errorDetails;
 
-			ReportToYouTrack(_youTrackProjectKeyErrors, summary, description, exitImmediately: false);
+			ReportToYouTrack(_youTrackProjectKeyErrors, summary, description, exitImmediately: false, bookModel: bookModel);
 		}
 
 		public void ReportMissingFont(string missingFontName, string harvesterId, BookModel bookModel = null)
@@ -179,7 +179,7 @@ namespace BloomHarvester.WebLibraryIntegration
 			string description = $"Missing font \"{missingFontName}\" on machine \"{harvesterId}\".\n\n";
 			description += GetDiagnosticInfo(bookModel, this.EnvironmentSetting);
 
-			ReportToYouTrack(_youTrackProjectKeyMissingFonts, summary, description, exitImmediately: false);
+			ReportToYouTrack(_youTrackProjectKeyMissingFonts, summary, description, exitImmediately: false, bookModel: bookModel);
 		}
 
 		private static string GetDiagnosticInfo(BookModel bookModel, EnvironmentSetting environment)

--- a/src/HarvesterTests/AlertManagerTests.cs
+++ b/src/HarvesterTests/AlertManagerTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using BloomHarvester;
+using BloomHarvester.Parse.Model;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using VSUnitTesting = Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -21,7 +23,7 @@ namespace BloomHarvesterTests
 		public void NoAlerts_NotSilenced()
 		{
 			var invoker = new VSUnitTesting.PrivateObject(AlertManager.Instance);
-			bool result = (bool)invoker.Invoke("IsSilenced");
+			bool result = (bool)invoker.Invoke("IsSilenced", new Object[] {null});
 			Assert.That(result, Is.False);
 		}
 
@@ -44,12 +46,12 @@ namespace BloomHarvesterTests
 		[Test]
 		public void ReportManyOldAlerts_NotSilenced()
 		{
-			var alertTimes = new LinkedList<DateTime>();
+			var alertTimes = new LinkedList<AlertManager.Alert>();
 			for (int i = 0; i < 100; ++i)
-				alertTimes.AddLast(DateTime.Now.AddDays(-3));
+				alertTimes.AddLast(new AlertManager.Alert { TimeStamp = DateTime.Now.AddDays(-3) });
 
 			var invoker = new VSUnitTesting.PrivateObject(AlertManager.Instance);
-			invoker.SetField("_alertTimes", alertTimes);
+			invoker.SetField("_alerts", alertTimes);
 
 			bool isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced();
 			Assert.That(isSilenced, Is.False);
@@ -70,6 +72,73 @@ namespace BloomHarvesterTests
 
 			isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced();
 			Assert.That(isSilenced, Is.True);
+		}
+
+		[TestCase("New")]
+		[TestCase("Updated")]
+		[TestCase("Requested")]
+		[TestCase("Failed")]
+		public void NewBookErrorsGetReportedOncePerBookOrMaxPerUploader(string harvestState)
+		{
+			// Fill in the maximum number of allowed daily alerts with default data.
+			for (var i = 0; i < AlertManager.kMaxAlertCount; ++i)
+			{
+				var isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced();
+				Assert.That(isSilenced, Is.False, $"book {i+1}");
+			}
+
+			var model1 = JsonConvert.DeserializeObject<BookModel>($"{{'baseUrl':'first book url','title':'First Book','uploader':{{'objectId':'uploader1'}},'harvestState':'{harvestState}'}}");
+			var model2 = JsonConvert.DeserializeObject<BookModel>($"{{'baseUrl':'second book url','title':'Second Book','uploader':{{'objectId':'uploader1'}},'harvestState':'{harvestState}'}}");
+			var model3 = JsonConvert.DeserializeObject<BookModel>($"{{'baseUrl':'third book url','title':'Third Book','uploader':{{'objectId':'uploader1'}},'harvestState':'{harvestState}'}}");
+			var model4 = JsonConvert.DeserializeObject<BookModel>($"{{'baseUrl':'fourth book url','title':'Fourth Book','uploader':{{'objectId':'uploader1'}},'harvestState':'{harvestState}'}}");
+			var model5 = JsonConvert.DeserializeObject<BookModel>($"{{'baseUrl':'fifth book url','title':'Fifth Book','uploader':{{'objectId':'uploader1'}},'harvestState':'{harvestState}'}}");
+			var model6 = JsonConvert.DeserializeObject<BookModel>($"{{'baseUrl':'sixth book url','title':'Sixth Book','uploader':{{'objectId':'uploader1'}},'harvestState':'{harvestState}'}}");
+			var model7 = JsonConvert.DeserializeObject<BookModel>($"{{'baseUrl':'seventh book url','title':'Seventh Book','uploader':{{'objectId':'uploader2'}},'harvestState':'{harvestState}'}}");
+			var model8 = JsonConvert.DeserializeObject<BookModel>($"{{'baseUrl':'eighth book url','title':'Eighth Book','uploader':{{'objectId':'uploader2'}},'harvestState':'{harvestState}'}}");
+
+			if (harvestState == "New" || harvestState == "Updated")
+			{
+				var isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model1);
+				Assert.That(isSilenced, Is.False, "first book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model2);
+				Assert.That(isSilenced, Is.False, "second book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model3);
+				Assert.That(isSilenced, Is.False, "third book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model4);
+				Assert.That(isSilenced, Is.False, "fourth book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model5);
+				Assert.That(isSilenced, Is.False, "fifth book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model6);
+				Assert.That(isSilenced, Is.True, "sixth book: too many by same uploader");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model7);
+				Assert.That(isSilenced, Is.False, "seventh book: new uploader");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model8);
+				Assert.That(isSilenced, Is.False, "eighth book");
+
+				model7.HarvestState = "Updated";
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model7);
+				Assert.That(isSilenced, Is.True, "seventh book updated: already reported once today");
+			}
+			else
+			{
+				// neither New nor Updated - silence the report!
+				var isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model1);
+				Assert.That(isSilenced, Is.True, "first book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model2);
+				Assert.That(isSilenced, Is.True, "second book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model3);
+				Assert.That(isSilenced, Is.True, "third book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model4);
+				Assert.That(isSilenced, Is.True, "fourth book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model5);
+				Assert.That(isSilenced, Is.True, "fifth book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model6);
+				Assert.That(isSilenced, Is.True, "sixth book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model7);
+				Assert.That(isSilenced, Is.True, "seventh book");
+				isSilenced = AlertManager.Instance.RecordAlertAndCheckIfSilenced(model8);
+				Assert.That(isSilenced, Is.True, "eighth book");
+			}
 		}
 	}
 }


### PR DESCRIPTION
This sidesteps the current limit of 5 error reports per day maximum.
There is now a limit of 1 report per new/updated book per day, and
5 reports per uploader of new/updated books per day, so there is still
some limits on bug reports per day, but not as strict for new (and
updated) books.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/131)
<!-- Reviewable:end -->
