### PR TITLE
Fix a null object crash in finding bookshelf (BH-6078 and BH-6083)

### DIFF
--- a/src/Harvester/BookAnalyzer.cs
+++ b/src/Harvester/BookAnalyzer.cs
@@ -107,6 +107,8 @@ namespace BloomHarvester
 			if (metaObj.IsDefined("tags"))
 			{
 				string[] tags = metaObj["tags"];
+				if (tags == null)
+					return String.Empty;
 				foreach (var tag in tags)
 				{
 					if (tag.StartsWith("bookshelf:"))


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/162)
<!-- Reviewable:end -->
