### PR TITLE
Update SIL.Core to match what Bloom uses (20220802)

### DIFF
--- a/src/Harvester/BloomHarvester.csproj
+++ b/src/Harvester/BloomHarvester.csproj
@@ -28,9 +28,10 @@
 		<!-- Without the explicit reference to Microsoft.Bcl.AsyncInterfaces, mscorlib was pulling in -->
 		<!-- version 1.1 after our PreBuild copy and that was causing runtime errors -->
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+		<PackageReference Include="Mono.Unix" version="7.1.0-final.1.21458.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="RestSharp" Version="106.12.0" />
-		<PackageReference Include="SIL.Core" Version="10.0.0-beta0063" />
+		<PackageReference Include="SIL.Core" Version="10.0.0-beta0081" />
 		<!-- Without the explicit reference to System.Runtime.CompilerServices.Unsafe, something (mscorlib?) was pulling in -->
 		<!-- version 4.5 after our PreBuild copy and that was causing runtime errors -->
 		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />

--- a/src/HarvesterTests/BloomHarvesterTests.csproj
+++ b/src/HarvesterTests/BloomHarvesterTests.csproj
@@ -10,12 +10,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Mono.Unix" version="7.1.0-final.1.21458.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="SIL.Core" Version="10.0.0-beta0063" />
+    <PackageReference Include="SIL.Core" Version="10.0.0-beta0081" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Also add Mono.Unix reference that is now needed by SIL.Core (or one of
the other libraries used by Bloom?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-harvester/178)
<!-- Reviewable:end -->
