### PR TITLE
Fix all build warnings

### DIFF
--- a/src/Harvester/BloomHarvester.csproj
+++ b/src/Harvester/BloomHarvester.csproj
@@ -3,7 +3,8 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0-windows</TargetFramework>
 		<UseWindowsForms>true</UseWindowsForms>
-		<UseWPF>false</UseWPF>
+		<!-- Bloom.dll depends on WPF assemblies (e.g. WindowsBase), so we need the WPF reference set. -->
+		<UseWPF>true</UseWPF>
 		<AssemblyVersion>6.0.0.0</AssemblyVersion>
 		<AssemblyFileVersion>6.0.0.0</AssemblyFileVersion>
 		<AssemblyInformationalVersion>6.0.0.0</AssemblyInformationalVersion>
@@ -30,6 +31,9 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="RestSharp" Version="106.12.0" />
 		<PackageReference Include="SIL.Core" Version="18.0.0-beta0001" />
+		<!-- Bloom's System.Management.dll needs System.CodeDom 9.0, which Bloom ships in lib/dotnet;
+		     reference it explicitly so the compiler doesn't pick the SDK's 8.0 version. -->
+		<PackageReference Include="System.CodeDom" Version="9.0.0" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
 		<PackageReference Include="System.Drawing.Common" Version="10.0.0" />
 	</ItemGroup>

--- a/src/Harvester/BookAnalyzer.cs
+++ b/src/Harvester/BookAnalyzer.cs
@@ -221,7 +221,7 @@ namespace BloomHarvester
 			{
 				mode = _publishSettings?.epub?.mode;
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
 				mode = "flowable";
 			}

--- a/src/Harvester/Logger/AzureMonitorLogger.cs
+++ b/src/Harvester/Logger/AzureMonitorLogger.cs
@@ -1,10 +1,10 @@
 using BloomHarvester.WebLibraryIntegration;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
 using SIL.IO;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -17,7 +17,8 @@ namespace BloomHarvester.Logger
 	/// </summary>
 	class AzureMonitorLogger : IMonitorLogger, IDisposable
 	{
-		private TelemetryClient _telemetry = new TelemetryClient();
+		private TelemetryConfiguration _telemetryConfiguration;
+		private TelemetryClient _telemetry;
 		private IMonitorLogger _fileLogger; // log to both Azure as well as something on the local filesystem, which would have more real-time access
 		private IIssueReporter _issueReporter;
 
@@ -37,16 +38,23 @@ namespace BloomHarvester.Logger
 			}
 
 			string instrumentationKey = Environment.GetEnvironmentVariable(environmentVarName);
-			Debug.Assert(!String.IsNullOrWhiteSpace(instrumentationKey), "Azure Instrumentation Key is invalid. Azure logging probably won't work.");
+			// Don't use Debug.Assert here: it is compiled out of Release builds (so it never
+			// protects production anyway), and in Debug builds it crashes unit tests.
+			if (String.IsNullOrWhiteSpace(instrumentationKey))
+				Console.Error.WriteLine("WARNING: Azure Instrumentation Key is invalid. Azure logging probably won't work.");
 
+			_telemetryConfiguration = TelemetryConfiguration.CreateDefault();
 			try
 			{
-				Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.Active.InstrumentationKey = instrumentationKey;
+				if (String.IsNullOrWhiteSpace(instrumentationKey))
+					throw new ArgumentException("Instrumentation key is null or whitespace.", nameof(instrumentationKey));
+				_telemetryConfiguration.ConnectionString = "InstrumentationKey=" + instrumentationKey;
 			}
-			catch (ArgumentNullException e)
+			catch (ArgumentException e)
 			{
 				_issueReporter.ReportException(e, $"InstrumentationKey: {instrumentationKey ?? "null"}.\nenvironmentVarName: {environmentVarName}", null);
 			}
+			_telemetry = new TelemetryClient(_telemetryConfiguration);
 
 			_telemetry.Context.User.Id = "BloomHarvester " + harvesterId;
 			_telemetry.Context.Session.Id = Guid.NewGuid().ToString();
@@ -98,6 +106,7 @@ namespace BloomHarvester.Logger
 			_telemetry.Flush();
 			Console.Out.WriteLine("Flushing AzureMonitor");
 			System.Threading.Thread.Sleep(5000);    // Allow some time to flush before shutdown. It might not flush right away. (https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#tracktrace)
+			_telemetryConfiguration.Dispose();
 		}
 
 		// Log a trace with Severity = Critical

--- a/src/Harvester/Parse/ParseClient.cs
+++ b/src/Harvester/Parse/ParseClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -60,7 +59,11 @@ namespace BloomHarvester.Parse
 		{
 			_environmentSetting = environment;
 			this.ApplicationId = GetApplicationId(environment);
-			Debug.Assert(!String.IsNullOrWhiteSpace(ApplicationId), "Parse Application ID is invalid. Retrieving books from Parse probably won't work. Consider checking your environment variables.");
+			// Don't use Debug.Assert here: it is compiled out of Release builds (so it never
+			// protects production anyway), and in Debug builds it crashes unit tests that
+			// construct a ParseClient without ever contacting the server.
+			if (String.IsNullOrWhiteSpace(ApplicationId))
+				Console.Error.WriteLine("WARNING: Parse Application ID is invalid. Retrieving books from Parse probably won't work. Consider checking your environment variables.");
 
 			Logger = logger;
 		}

--- a/src/HarvesterTests/BloomHarvesterTests.csproj
+++ b/src/HarvesterTests/BloomHarvesterTests.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows7.0</TargetFramework>
 	<UseWindowsForms>true</UseWindowsForms>
-	<UseWPF>false</UseWPF>
+	<!-- Bloom.dll depends on WPF assemblies (e.g. WindowsBase), so we need the WPF reference set. -->
+	<UseWPF>true</UseWPF>
 
     <IsPackable>false</IsPackable>
 

--- a/src/HarvesterTests/HarvesterTests.cs
+++ b/src/HarvesterTests/HarvesterTests.cs
@@ -47,6 +47,7 @@ namespace BloomHarvesterTests
 			_fakeIssueReporter = null;
 			_logger = Substitute.For<IMonitorLogger>();
 			_fakeBloomCli = null;
+			_fakeFontChecker = null;
 			_fakeDiskSpaceManager = Substitute.For<IDiskSpaceManager>();	// This will basically null-op whenever CleanupIfNeeded is called.
 			_fakeFileIO = null;
 		}


### PR DESCRIPTION
Fixes every warning in the solution build (was 4 distinct warnings, now 0):

- **CS0168**: remove unused exception variable in `BookAnalyzer.IsEpubSuitable`
- **CS0649**: reset `_fakeFontChecker` in test SetUp like the other fake fields
- **CS0618** (x3): replace deprecated `TelemetryConfiguration.Active` / `InstrumentationKey` with an explicit `TelemetryConfiguration` using a connection string (the documented ApplicationInsights migration path)
- **MSB3277** (WindowsBase): enable `UseWPF` since Bloom.dll depends on WPF's WindowsBase 8.0, not the non-WPF 4.0 stub
- **MSB3277** (System.CodeDom): reference System.CodeDom 9.0 explicitly to match what Bloom's System.Management.dll needs (and what lib/dotnet ships)

Also replaces two `Debug.Assert` calls about missing environment variables (`ParseClient`, `AzureMonitorLogger`) with stderr warnings: `Debug.Assert` is compiled out of Release builds so it never protected the deployed harvester, and in Debug builds it crashed two unit tests that construct a Harvester without contacting the server. Full test suite now passes 343/343 locally (was 341 + 2 environment-dependent failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-harvester/234)
<!-- Reviewable:end -->
